### PR TITLE
label can be after reference (and save-excursion if not found format2 case)

### DIFF
--- a/reftex-xref.el
+++ b/reftex-xref.el
@@ -44,10 +44,12 @@
               (re (format reftex-find-label-regexp-format (regexp-quote label)))
               (found (with-current-buffer buffer
                        (or (re-search-backward re nil t)
-                           (progn (goto-char (point-min))
-                                  (re-search-forward
-                                   (format reftex-find-label-regexp-format2
-                                           (regexp-quote label))
+                           (re-search-forward re nil t)
+                           (save-excursion
+                             (goto-char (point-min))
+                             (re-search-forward
+                              (format reftex-find-label-regexp-format2
+                                      (regexp-quote label))
                                    nil t))))))
     (list (xref-make prompt (xref-make-buffer-location
                              buffer found)))))


### PR DESCRIPTION
`\label{}` can be after `\ref{}`: 

- in a tedious explanation sometimes you postpone some concepts later,
- when multi-files searching you can not know in advance where is the `point` of in a given buffer: the `\label{}` you are searching can be before of after `point`.

Moreover when the second form of regexp is conducted `point-min` is used and if the search fails the point remain at the beginning of buffer -> a `save-excursion` is introduced for this corner case.